### PR TITLE
Fill in case for Psig_value

### DIFF
--- a/src/ppx_gen_rec.ml
+++ b/src/ppx_gen_rec.ml
@@ -44,8 +44,8 @@ and module_binding_of_declaration { pmd_name; pmd_type; pmd_attributes; pmd_loc;
   }
 
 and structure_item_desc_of_signature_item_desc = function
-  | Psig_value _value_description ->
-      raise_errorf "ppx_gen_rec: Psig_value not supported yet"
+  | Psig_value value_description ->
+      Pstr_primitive value_description
   | Psig_type (rec_flag, decls) ->
       Pstr_type (rec_flag, decls)
   | Psig_typext type_extension ->


### PR DESCRIPTION
This is based on
https://github.com/ocaml/ocaml/blob/04123df28f20cf02a7220471baea0d1a8ee7a056/parsing/parsetree.mli#L696
and
https://github.com/ocaml/ocaml/blob/04123df28f20cf02a7220471baea0d1a8ee7a056/parsing/parsetree.mli#L825