### PR TITLE
Set the precedence for ppx_gen_rec to -10

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+v1.1.0 2019-04-04
+-----------------
+
+Set the ocaml-migrate-parsetree priority to -10, so as to run before ppx_deriving
+Switch from jbuilder to dune
+
 v1.0.0 2018-07-06
 -----------------
 

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -1,6 +1,0 @@
-(* Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved *)
-
-#use "topfind"
-#require "topkg-jbuilder"
-
-let () = Topkg_jbuilder.describe ~licenses:[ Topkg.Pkg.std_file "LICENSE" ] ()

--- a/ppx_gen_rec.opam
+++ b/ppx_gen_rec.opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/flowtype/ocaml-ppx_gen_rec.git"
 bug-reports: "https://github.com/flowtype/ocaml-ppx_gen_rec/issues"
 depends:
 [
-  "jbuilder" {build & >= "1.0+beta7"}
+  "dune" {build}
   "ocaml-migrate-parsetree"
 ]
-build: [["jbuilder" "build" "-p" name "-j" jobs]]
+build: [["dune" "build" "-p" name "-j" jobs]]

--- a/ppx_gen_rec.opam
+++ b/ppx_gen_rec.opam
@@ -9,6 +9,6 @@ bug-reports: "https://github.com/flowtype/ocaml-ppx_gen_rec/issues"
 depends:
 [
   "dune" {build}
-  "ocaml-migrate-parsetree"
+  "ocaml-migrate-parsetree" { >= "1.1.0" }
 ]
 build: [["dune" "build" "-p" name "-j" jobs]]

--- a/src/ppx_gen_rec.ml
+++ b/src/ppx_gen_rec.ml
@@ -118,5 +118,5 @@ let structure_item mapper = function
 let gen_rec_mapper = { default_mapper with structure_item }
 
 let () =
-  Driver.register ~name:"ppx_gen_rec" Versions.ocaml_405
+  Driver.register ~name:"ppx_gen_rec" ~position:~-10 Versions.ocaml_405
     (fun _config _cookies -> gen_rec_mapper)


### PR DESCRIPTION
This should allow `ppx_gen_rec` to run with `ppx_deriving` without errors.

I have a library with a `dune` file that looks like this

```
(library
  (name flow_src_parser_parser)
  (wrapped false)
  (modules
    ...
    flow_ast
    ...)
  (libraries
    ppx_deriving.runtime
    sedlex
    wtf8)
  (preprocess
    (pps
      ppx_deriving.std
      ppx_gen_rec
      sedlex.ppx)))
```

`dune` creates a single ppx binary that runs all 3 preprocessors. Unfortunately, I would get errors like 

```
$ dune build _build/default/src/parser/flow_src_parser_flow_parser_js.cmxa
         ppx src/parser/flow_ast.pp.ml (exit 1)
(cd _build/default && .ppx/ppx_deriving.std+ppx_gen_rec/ppx.exe --cookie 'library-name="flow_src_parser_ast"' -o src/parser/flow_ast.pp.ml --impl src/parser/flow_ast.ml --dump-ast)
File "_none_", line 1:
Error: ppx_gen_rec: Psig_value not supported yet
```

`dune` doesn't support running multiple phases of preprocessors. And an issue talking about it (https://github.com/ocaml/dune/issues/1135) was against adding the feature. Luckily `ocaml-migrate-parsetree` added a feature in 1.1.0 which allows a preprocessor to specify it's `position` (https://github.com/ocaml-ppx/ocaml-migrate-parsetree/pull/51)

If I set the position to -10, run `opam pin add ppx_gen_rec .`, then my `dune build` succeeds!